### PR TITLE
Ignore carthage checkouts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build
 


### PR DESCRIPTION
If users need to install depencencies they can run the buddy build
script