### PR TITLE
Recommend script instead of raw carthage commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Track work hours automatically.
 
 # For Developers
 Before building the project with Xcode you'll need to build the dependencies
-using [Carthage](https://github.com/Carthage/Carthage).
+using [Carthage](https://github.com/Carthage/Carthage). It's probably best to use the same script that CI uses to keep everything consistent. 
 
 ```
-carthage bootstrap --platform iOS
+./buddybuild_carthage_command.sh
 ```


### PR DESCRIPTION
Just keeps our work flow more consistent. 
This way we don't have someone on their own machine, building with no binaries and swift 4, but then everything breaks on the server..... with the "works on my machine" problem. 