### PR TITLE
Removed the FIXME TODO build rule.

### DIFF
--- a/WorkWeek.xcodeproj/project.pbxproj
+++ b/WorkWeek.xcodeproj/project.pbxproj
@@ -19,14 +19,14 @@
 		5287CA401EDCF91E00E71CE8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5287CA3E1EDCF91E00E71CE8 /* LaunchScreen.storyboard */; };
 		5287CA4D1EDCFB8400E71CE8 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5287CA491EDCFA9200E71CE8 /* Realm.framework */; };
 		5287CA4E1EDCFB8400E71CE8 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5287CA4A1EDCFA9200E71CE8 /* RealmSwift.framework */; };
-		D1CA47031EE354B9003628FF /* DailyTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CA47021EE354B9003628FF /* DailyTableViewController.swift */; };
-		D1CA47051EE354FC003628FF /* WeeklyTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CA47041EE354FC003628FF /* WeeklyTableViewController.swift */; };
-		D1CA47071EE35528003628FF /* ActivityPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CA47061EE35528003628FF /* ActivityPageViewController.swift */; };
 		C362A4071EE34EA200AB9830 /* Onboarding.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C362A4061EE34EA200AB9830 /* Onboarding.storyboard */; };
 		C362A4091EE3517800AB9830 /* OnboardPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C362A4081EE3517800AB9830 /* OnboardPageViewController.swift */; };
 		C362A40B1EE35DD500AB9830 /* OnboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C362A40A1EE35DD500AB9830 /* OnboardViewController.swift */; };
 		C3B0C4521EE377180000D097 /* StoryboardProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B0C4511EE377180000D097 /* StoryboardProtocols.swift */; };
 		C3B0C4541EE3CC930000D097 /* PageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B0C4531EE3CC930000D097 /* PageManager.swift */; };
+		D1CA47031EE354B9003628FF /* DailyTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CA47021EE354B9003628FF /* DailyTableViewController.swift */; };
+		D1CA47051EE354FC003628FF /* WeeklyTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CA47041EE354FC003628FF /* WeeklyTableViewController.swift */; };
+		D1CA47071EE35528003628FF /* ActivityPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CA47061EE35528003628FF /* ActivityPageViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,14 +44,14 @@
 		5287CA411EDCF91E00E71CE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5287CA491EDCFA9200E71CE8 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../Carthage/Build/iOS/Realm.framework; sourceTree = "<group>"; };
 		5287CA4A1EDCFA9200E71CE8 /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = ../Carthage/Build/iOS/RealmSwift.framework; sourceTree = "<group>"; };
-		D1CA47021EE354B9003628FF /* DailyTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DailyTableViewController.swift; sourceTree = "<group>"; };
-		D1CA47041EE354FC003628FF /* WeeklyTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeeklyTableViewController.swift; sourceTree = "<group>"; };
-		D1CA47061EE35528003628FF /* ActivityPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityPageViewController.swift; sourceTree = "<group>"; };
 		C362A4061EE34EA200AB9830 /* Onboarding.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Onboarding.storyboard; sourceTree = "<group>"; };
 		C362A4081EE3517800AB9830 /* OnboardPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardPageViewController.swift; sourceTree = "<group>"; };
 		C362A40A1EE35DD500AB9830 /* OnboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardViewController.swift; sourceTree = "<group>"; };
 		C3B0C4511EE377180000D097 /* StoryboardProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardProtocols.swift; sourceTree = "<group>"; };
 		C3B0C4531EE3CC930000D097 /* PageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageManager.swift; sourceTree = "<group>"; };
+		D1CA47021EE354B9003628FF /* DailyTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DailyTableViewController.swift; sourceTree = "<group>"; };
+		D1CA47041EE354FC003628FF /* WeeklyTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeeklyTableViewController.swift; sourceTree = "<group>"; };
+		D1CA47061EE35528003628FF /* ActivityPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityPageViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,10 +93,10 @@
 				C3B0C4531EE3CC930000D097 /* PageManager.swift */,
 				5287CA351EDCF91E00E71CE8 /* AppDelegate.swift */,
 				D1CA47011EE34D9F003628FF /* Activity */,
-                C362A4061EE34EA200AB9830 /* Onboarding.storyboard */,
-                C362A4081EE3517800AB9830 /* OnboardPageViewController.swift */,
-                C362A40A1EE35DD500AB9830 /* OnboardViewController.swift */,
-                C3B0C4511EE377180000D097 /* StoryboardProtocols.swift */,
+				C362A4061EE34EA200AB9830 /* Onboarding.storyboard */,
+				C362A4081EE3517800AB9830 /* OnboardPageViewController.swift */,
+				C362A40A1EE35DD500AB9830 /* OnboardViewController.swift */,
+				C3B0C4511EE377180000D097 /* StoryboardProtocols.swift */,
 				5287CA3C1EDCF91E00E71CE8 /* Assets.xcassets */,
 				5287CA3E1EDCF91E00E71CE8 /* LaunchScreen.storyboard */,
 				5287CA411EDCF91E00E71CE8 /* Info.plist */,
@@ -143,7 +143,6 @@
 				5287CA471EDCFA2D00E71CE8 /* Copy Carthage Frameworks */,
 				523511671EDDB7F00093B125 /* Swiftlint Files */,
 				5208F3A91EDE4BC9008F82CC /* Do Fabric Things */,
-				5208F3B01EDE6A9F008F82CC /* Warn for FIXME and TODO */,
 				5208F3B11EDE6BB8008F82CC /* Bump Version Number for Release builds */,
 			);
 			buildRules = (
@@ -219,20 +218,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "./Fabric.framework/run 993252beacbf2387f597b3284548e20828ae2643 9e9bac7398eecbf08f8597321214eda953841c7b981b9e48b750f7a4cc3ac84e";
-		};
-		5208F3B01EDE6A9F008F82CC /* Warn for FIXME and TODO */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Warn for FIXME and TODO";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "KEYWORDS=\"TODO|FIXME|TEMP|\\?\\?\\?:|\\!\\!\\!:\"\nfind \"${SRCROOT}\" \\( -name \"*.swift\" \\) -print0 | \\\nxargs -0 egrep --with-filename --line-number --only-matching \"($KEYWORDS).*\\$\" | \\\nperl -p -e \"s/($KEYWORDS)/ warning: \\$1/\"";
 		};
 		5208F3B11EDE6BB8008F82CC /* Bump Version Number for Release builds */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Basically, we were getting false positives from Realm Swift.... And I
could figure out how to make this rule, ignore the Carthage folder...
There is a swiftlint rule which checks for FIXME and TODO's already.

This rule was a bit more flexible in that it looked for
```
KEYWORDS="TODO|FIXME|TEMP|\?\?\?:|\!\!\!:"
```
but No one is yet addind `//???` or `//!!!` so let's just not do that
going forward.