### PR TITLE
Turn off TODO and trailing new line swift line warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,10 @@
 excluded:
     - Carthage
 
+disabled_rules:
+    - todo
+    - trailing_newline
+
 vertical_whitespace:
     max_empty_lines: 2
 


### PR DESCRIPTION
Because they are a bit overly pedantic and silly.

@MadeByDouglas Had a bit of a discussion about the todo warning in another pull request.
https://github.com/MadeByDouglas/workweekSPARK/pull/17#issuecomment-310790379

Wanted to open this up for any potential discussion.

### Screenshot for clarity
![screen shot 2017-06-24 at 12 27 31 pm](https://user-images.githubusercontent.com/573579/27511424-87082b44-58d8-11e7-95ec-dd1edb54b09b.png)