### PR TITLE
Bump line length warning to 140 characters

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,3 +8,5 @@ disabled_rules:
 vertical_whitespace:
     max_empty_lines: 2
 
+line_length:
+    warning: 140


### PR DESCRIPTION
Bump line length warning to 140 characters