### PR TITLE
Be able to log without a message.

### DIFF
--- a/WorkWeek/AppCoordinator.swift
+++ b/WorkWeek/AppCoordinator.swift
@@ -17,7 +17,7 @@ class AppCoordinator: OnboardingCoordinatorDelegate, SettingsCoordinatorDelegate
     }
 
     func start() {
-        Log.log("\(#file): \(#function)")
+        Log.log()
 
         #if DEBUG  // In Debug modes allow going straight to the settings page if, the userdefault key is set
             let showSettingsDEBUG = UserDefaults.standard.bool(for: .overrideShowSettingsFirst)

--- a/WorkWeek/Log.swift
+++ b/WorkWeek/Log.swift
@@ -36,7 +36,7 @@ final class Log {
     ///
     /// - Parameters:
     ///   - message: The Message string to be logged
-    static func log(_ message: String,
+    static func log(_ message: String = "-",
                     _ file: String = #file,
                     _ function: String = #function,
                     _ line: Int = #line) {
@@ -50,7 +50,7 @@ final class Log {
     ///   - level: The importance of your message
     ///   - message: What you want to say
     static func log(_ level: Level,
-                    _ message: String,
+                    _ message: String = "-",
                     _ file: String = #file,
                     _ function: String = #function,
                     _ line: Int = #line) {

--- a/WorkWeek/OnboardingCoordinator.swift
+++ b/WorkWeek/OnboardingCoordinator.swift
@@ -25,7 +25,7 @@ class OnboardingCoordinator: OnboardPageViewDelegate {
     }
 
     func start() {
-        Log.log("\(#file): \(#function)")
+        Log.log()
         let initial = OnboardPageViewController.instantiate()
         initial.onboardDelegate = self
 

--- a/WorkWeek/SettingsCoordinator.swift
+++ b/WorkWeek/SettingsCoordinator.swift
@@ -25,7 +25,7 @@ class SettingsCoordinator: SettingsMainProtocol, MapVCDelegate {
     }
 
     func start() {
-        Log.log("\(#file): \(#function)")
+        Log.log()
 
         navigationController.isNavigationBarHidden = true
 


### PR DESCRIPTION
There were a few places where we logged the file and function, without
really passing a message.
This was a bit silly and redundant because the file and function are
logged by default with all messages. It is nice for tracing purposes, to
be able to see these simple flow log messages "This function got called"
so by default we'll just log a dash no need for you to put anything in
the message if you don't want to.
The default message will look like this now

```
2017-07-06 17:08:08.302 WorkWeek[57189:1841438] [debug] (start(), AppCoordinator.swift:20) : -
```