### PR TITLE
Add functional search to map views

### DIFF
--- a/WorkWeek/CLLocationManager+Extensions.swift
+++ b/WorkWeek/CLLocationManager+Extensions.swift
@@ -37,3 +37,29 @@ extension CLLocationManager {
         return circles.map { MKCircle(center: $0.center, radius: $0.radius) }
     }
 }
+
+extension MKLocalSearch {
+    typealias SearchResult = Result<MKLocalSearchResponse, SearchErrors>
+    enum Result<T, Error> {
+        case success(T)
+        case failure(Error)
+    }
+    enum SearchErrors {
+        case bothResponseAndErrorNil
+        case error(Error)
+    }
+    func startResult(completionHandler: @escaping (SearchResult) -> Void) {
+        start(completionHandler: { (response, error) in
+            if let error = error {
+                completionHandler(.failure(.error(error)))
+                return
+            }
+            guard let response = response else {
+                let err = SearchErrors.bothResponseAndErrorNil
+                completionHandler(.failure(err))
+                return
+            }
+            completionHandler(.success(response))
+        })
+    }
+}


### PR DESCRIPTION
When a search is performed the search for your query is logged, and the
search is performed by apple's service, on the current visible map
region.

You probably noticed my `Result`... basically when an API gives you, a
completion handler of type `(thing: Thing?, error: Error?) -> Void`
there is no guarantee that both of those things are not `nil` so maybe
you perform a search but you get back a nil response and a nil error! We
now have a type system that can help us deal with these either or
situations. So we'll encode it.