### PR TITLE
Skip swiftlint on CI

### DIFF
--- a/WorkWeek.xcodeproj/project.pbxproj
+++ b/WorkWeek.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# if running on CI skip\nif [ -v BUDDYBUILD_BUILD_NUMBER]; then\n    exit 0 # success, skip on CI\nfi\n\nif which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "# if running on CI skip\nif [ -n \"$BUDDYBUILD_APP_ID\" ] ; then\n    echo \"CI Detected. Skipping Linting, appID ${BUDDYBUILD_APP_ID}\"\n    exit 0 # success, skip on CI\nfi\n\nif which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		5287CA471EDCFA2D00E71CE8 /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Now that we have the Danger bot running during CI builds to complain at us about various things... including swift lint things. We should run swiftlint only as part of danger when running during CI builds.

1. When developer is building locally swiftlint runs as part of Xcode.
2. When building on CI, swift lint is skipped during the build, but run after as part of Danger. 