### PR TITLE
Have the Coordinator display the debug menu

### DIFF
--- a/WorkWeek/ActivityCoordinator.swift
+++ b/WorkWeek/ActivityCoordinator.swift
@@ -45,6 +45,9 @@ class ActivityCoordinator: NSObject, SettingsCoordinatorDelegate, UINavigationCo
         countdownVC.data = CountDown()
         countdownVC.delegate = self
         countdownVC.selectionDelegate = self
+        #if DEBUG
+            countdownVC.debugDelegate = self
+        #endif
 
         if animated {
             navigationController.viewControllers.insert(countdownVC, at: 0)
@@ -105,5 +108,11 @@ extension ActivityCoordinator: CountdownViewDelegate {
 extension ActivityCoordinator: WeeklySelectionDelegate {
     func selectedWeek(_ week: String) {
         showWeeklyViewController(for: week)
+    }
+}
+
+extension ActivityCoordinator: DebugMenuShowing {
+    func showDebugMenu() {
+        navigationController.presentDevSettingsAlertController()
     }
 }

--- a/WorkWeek/CountdownViewController.swift
+++ b/WorkWeek/CountdownViewController.swift
@@ -5,6 +5,12 @@
 import UIKit
 import Reusable
 
+#if DEBUG
+protocol DebugMenuShowing: class {
+    func showDebugMenu()
+}
+#endif
+
 protocol CountdownViewDelegate: class {
     func countdownPageDidTapSettings()
 }
@@ -57,6 +63,7 @@ final class CountdownViewController: UIViewController {
     }
 
     #if DEBUG
+    weak var debugDelegate: DebugMenuShowing?
     // We are willing to become first responder to get shake motion
     override var canBecomeFirstResponder: Bool {
             return true
@@ -65,7 +72,7 @@ final class CountdownViewController: UIViewController {
     // Enable detection of shake motion
     override func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
         if motion == .motionShake {
-            self.navigationController?.presentDevSettingsAlertController()
+            debugDelegate?.showDebugMenu()
         }
     }
     #endif
@@ -98,7 +105,6 @@ final class CountdownViewController: UIViewController {
 }
 
 extension CountdownViewController: ActivityStoryboard { }
-
 
 protocol WeeklySelectionDelegate: class {
     func selectedWeek(_ week: String)


### PR DESCRIPTION
Moving this to the coordinator is a nice little win because not the VC does not need to know or hope that it's in a Navigation controller? (even though the debug menu does not use the navigation contorller) and then we let the coordinator handle all of our uiview controller presentation. 
Really I ran into this when trying to stand up the Countdown vc in a Storyboard, I needed to pull in navigation extenssions, then I needed to know about realm..adn pretty soon the whole app was requied just to create a vc in a  playground.

Added one little protocol, Dependency smashed. Now when we decide to remove the debug menu some day. It'll be easy peasy.
(plus we can develop our view controllers in a playground if we want to.)