### PR TITLE
Add a new file header template for WorkWeek

### DIFF
--- a/WorkWeek.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/WorkWeek.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+// Copyright © ___YEAR___ ___ORGANIZATIONNAME___ All rights reserved.
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
Just auto formats the header comment for you. 

Other macros could be added, we could adjust this one if we want. More info can be found here: 
https://oleb.net/blog/2017/07/xcode-9-text-macros/

Fixes #108 

Like this: 

![2017-10-09 16_52_56](https://user-images.githubusercontent.com/573579/31363299-60335258-ad12-11e7-914e-435edf675314.gif)
